### PR TITLE
fix readme installation for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Building:
 ```sh
 $ git clone https://github.com/Eliovp/amdmemorytweak
 $ cd amdmemorytweak/linux
-$ g++ amdmemorytweak.cpp -lpci -lresolv -o amdmemtweak
+$ g++ AmdMemTweak.cpp -lpci -lresolv -o amdmemtweak
 ```
 
 # Build (Windows)


### PR DESCRIPTION
- this fixes the linux installation step in the readme (the file path names were different)